### PR TITLE
Update Sister app link to Apple App Store

### DIFF
--- a/components/Work.tsx
+++ b/components/Work.tsx
@@ -18,7 +18,7 @@ const workItems: WorkItem[] = [
   {
     name: "Sister",
     description: "AI beauty assistant. Grew to 2M+ users.",
-    href: "https://trysister.com",
+    href: "https://apps.apple.com/us/app/sister-glow-up/id6502375076",
   },
   {
     name: "RunPod",


### PR DESCRIPTION
## Summary
Updated the external link for the Sister app from the marketing website to the Apple App Store listing.

## Changes
- Changed Sister app href from `https://trysister.com` to `https://apps.apple.com/us/app/sister-glow-up/id6502375076`

## Details
This update directs users to the official Apple App Store page for the Sister app, providing a more direct path to download the application rather than routing through the marketing website.

https://claude.ai/code/session_01VsrcsVJjhhVVxCyJyWxxn8