### PR TITLE
Add JustBuild to work experience section

### DIFF
--- a/components/Work.tsx
+++ b/components/Work.tsx
@@ -27,7 +27,7 @@ const workItems: WorkItem[] = [
   },
   {
     name: "JustBuild",
-    description: "Community connecting Silicon Valley to Silicon Slopes. Making Utah AI-native.",
+    description: "Utah's largest community of engineers. Hosting monthly hackathons.",
     href: "https://justbuild.ing",
   },
   {

--- a/components/Work.tsx
+++ b/components/Work.tsx
@@ -26,6 +26,11 @@ const workItems: WorkItem[] = [
     href: "https://runpod.io",
   },
   {
+    name: "JustBuild",
+    description: "Community connecting Silicon Valley to Silicon Slopes. Making Utah AI-native.",
+    href: "https://justbuild.ing",
+  },
+  {
     name: "Proxy",
     description: "AI startup. Built the product from zero to revenue.",
   },


### PR DESCRIPTION
## Summary
Added JustBuild to the work items list in the Work component, expanding the portfolio of projects and experiences showcased.

## Changes
- Added new work item entry for JustBuild with:
  - Name: "JustBuild"
  - Description: "Utah's largest community of engineers. Hosting monthly hackathons."
  - Link: https://justbuild.ing
  - Positioned between RunPod and Proxy entries in the work items array

## Details
This addition highlights involvement with a community-focused engineering initiative, complementing the existing work experience entries that showcase both startup and infrastructure projects.

https://claude.ai/code/session_01QcW8nD9nebkxSWndhTYXJf